### PR TITLE
Add version catalog to project

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,33 @@
+[versions]
+agp = "7.3.1"
+androidx-appcompat = "1.5.1"
+androidx-core = "1.8.0"
+androidx-compose-activity = "1.7.0-alpha03"
+compose-bom = "2022.10.00"
+compose-compiler = "1.3.2"
+google-material = "1.7.0"
+gradle-publish-plugin = "1.0.0"
+junit-jupiter = "5.8.2"
+junit-stnd = "4.13.2"
+kotlin = "1.7.20"
+kotlinx-serialization = "1.4.0"
+mockk = "1.13.3"
+
+[libraries]
+agp-tools = { module = "com.android.tools.build:gradle", version.ref = "agp"}
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat"}
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-compose-material = { group = "androidx.compose.material", name = "material" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-compose-activity"}
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter",  version.ref = "junit-jupiter" }
+junit-stnd = { module = "junit:junit", version.ref = "junit-stnd" }
+kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
+kotlin-gradle-plugin-stnd = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
+
+kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
     compileOptions {
@@ -48,24 +48,17 @@ verifyComposeMetricsConfig {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2022.10.00")
+    val composeBom = platform(libs.androidx.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    // Android Studio Preview support
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    implementation("androidx.compose.material:material")
-    implementation("androidx.compose.foundation:foundation")
-    implementation("androidx.compose.ui:ui")
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.ui)
 
-    implementation("androidx.activity:activity-compose:1.7.0-alpha03")
+    implementation(libs.androidx.compose.activity)
 
-    implementation("androidx.core:core-ktx:1.8.0")
-    implementation("androidx.appcompat:appcompat:1.5.1")
-    implementation("com.google.android.material:material:1.7.0")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20")
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.4")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.google.material)
 }

--- a/sample/lib/build.gradle.kts
+++ b/sample/lib/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
     compileOptions {
@@ -46,23 +46,17 @@ verifyComposeMetricsConfig {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2022.10.00")
+    val composeBom = platform(libs.androidx.compose.bom)
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
-    // Android Studio Preview support
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    implementation("androidx.compose.material:material")
-    implementation("androidx.compose.foundation:foundation")
-    implementation("androidx.compose.ui:ui")
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.ui)
 
-    implementation("androidx.activity:activity-compose:1.7.0-alpha03")
+    implementation(libs.androidx.compose.activity)
 
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.6.0")
-    implementation("com.google.android.material:material:1.7.0")
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.google.material)
 }

--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -8,9 +8,20 @@ pluginManagement {
         google()
         gradlePluginPortal()
     }
-
-    includeBuild("../verifyComposeMetricsPlugin")
 }
+
+enableFeaturePreview("VERSION_CATALOGS")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
 rootProject.name = "VerifyComposeMetricsSample"
 include ':app'
 include ':lib'
+
+includeBuild("../")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
 rootProject.name = "VerifyComposeMetrics"
 include ':app'
-//include ':verifyComposeMetricsPlugin'
-includeBuild("verifyComposeMetricsPlugin")
+include("verifyComposeMetricsPlugin")

--- a/verifyComposeMetricsPlugin/build.gradle.kts
+++ b/verifyComposeMetricsPlugin/build.gradle.kts
@@ -2,12 +2,11 @@ import org.gradle.kotlin.dsl.`kotlin-dsl`
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.7.20"
     `kotlin-dsl`
     `java-gradle-plugin`
-    kotlin("plugin.serialization") version "1.7.20"
+    kotlin("plugin.serialization") version libs.versions.kotlin.get()
     `java-library`
-    id("com.gradle.plugin-publish") version "1.0.0"
+    id("com.gradle.plugin-publish") version libs.versions.gradle.publish.plugin.get()
 }
 
 repositories {
@@ -25,31 +24,31 @@ val integrationTest: SourceSet by sourceSets.creating
 val functionalTest: SourceSet by sourceSets.creating
 
 dependencies {
-    implementation(kotlin("stdlib", "1.7.20"))
-    implementation("com.android.tools.build:gradle:7.3.1")
+    implementation(kotlin("stdlib", libs.versions.kotlin.get()))
+    implementation(libs.agp.tools)
     implementation(gradleApi())
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.7.20")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+    implementation(libs.kotlin.gradle.plugin.api)
+    implementation(libs.kotlinx.serialization)
+    implementation(libs.kotlin.gradle.plugin.stnd)
 
     // Test dependencies
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.13.3")
-    testImplementation("com.android.tools.build:gradle:7.3.1")
+    testImplementation(libs.junit.stnd)
+    testImplementation(libs.mockk)
+    testImplementation(libs.junit.jupiter)
 
     // Integration test dependency
     "integrationTestImplementation"(project)
-    "integrationTestImplementation"("org.junit.jupiter:junit-jupiter:5.8.2")
+    "integrationTestImplementation"(libs.junit.jupiter)
     "integrationTestImplementation"(gradleTestKit())
     "integrationTestImplementation"(kotlin("script-runtime"))
 
     // Functional test dependency
     "functionalTestImplementation"(project)
-    "functionalTestImplementation"("org.junit.jupiter:junit-jupiter:5.8.2")
-    "functionalTestImplementation"("org.jetbrains.kotlin:kotlin-test")
+    "functionalTestImplementation"(libs.junit.jupiter)
+    "functionalTestImplementation"(libs.kotlin.test)
     "functionalTestImplementation"(gradleTestKit())
     "functionalTestImplementation"(kotlin("script-runtime"))
-    "functionalTestImplementation"("com.android.tools.build:gradle:7.3.1")
+    "functionalTestImplementation"(libs.agp.tools)
 }
 
 project.tasks.withType<KotlinCompile>().configureEach {


### PR DESCRIPTION
Add version catalog to the project and clean up sample dependencies. We were importing a lot that we did not need to make the sample apps. This was probably autogenerated by Android Studio when I made the first draw of the project.

Resolves #5 