### PR TITLE
Upgrade kotlin gradle plugin to match Compose compiler plugin version

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
         maven(url = "https://jitpack.io")
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
         classpath("com.android.tools.build:gradle:7.3.1+")
     }
 }


### PR DESCRIPTION
Renovate had not upgraded this when upgrading Kotlin, so it broke the sample app.